### PR TITLE
Don't fail on traits with multipleuse sniff

### DIFF
--- a/Zumba/Sniffs/PHP/DisallowMultipleUseSniff.php
+++ b/Zumba/Sniffs/PHP/DisallowMultipleUseSniff.php
@@ -25,13 +25,20 @@ class Zumba_Sniffs_PHP_DisallowMultipleUseSniff implements PHP_CodeSniffer_Sniff
     protected $firstUse = array();
 
     /**
+     * Whether the current file saw a class.
+     *
+     * @var array
+     */
+    protected $seenClass = array();
+
+    /**
      * Returns an array of tokens this test wants to listen for.
      *
      * @return array
      */
     public function register()
     {
-        return array(T_USE);
+        return array(T_USE, T_CLASS);
 
     }//end register()
 
@@ -49,6 +56,14 @@ class Zumba_Sniffs_PHP_DisallowMultipleUseSniff implements PHP_CodeSniffer_Sniff
     {
         $tokens = $phpcsFile->getTokens();
         $filename = $phpcsFile->getFilename();
+
+        // disable for traits:
+        if ($tokens[$stackPtr]['code'] === T_CLASS) {
+            $this->seenClass[$filename] = true;
+        }
+        if (!empty($this->seenClass[$filename])) {
+            return;
+        }
 
         if (!isset($this->firstUse[$filename])) {
             $this->firstUse[$filename] = $tokens[$stackPtr];


### PR DESCRIPTION
Fix by tracking the class statement, and disabling once we see one of
those.
