### PR TITLE
upgrade php_codesniffer to v1.5.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,6 @@
 	],
 	"require": {
 		"php": ">=5.3.10",
-		"squizlabs/php_codesniffer": "1.4.6"
+		"squizlabs/php_codesniffer": "1.5.3"
 	}
 }


### PR DESCRIPTION
this fixes an issue where namespaces ending in `MySQL` would be interpreted as usage of the deprecated `mysql()` function and cause code_sniffer to error out.

/cc @jrbasso @dmatsingerzumba @cjsaylor 