### PR TITLE
Fix multi use for traits

### DIFF
--- a/Zumba/Sniffs/PHP/DisallowMultipleUseSniff.php
+++ b/Zumba/Sniffs/PHP/DisallowMultipleUseSniff.php
@@ -29,7 +29,7 @@ class Zumba_Sniffs_PHP_DisallowMultipleUseSniff implements PHP_CodeSniffer_Sniff
      *
      * @var array
      */
-    protected $seenClass = array();
+    protected $seenClassOrTrait = array();
 
     /**
      * Returns an array of tokens this test wants to listen for.
@@ -38,7 +38,7 @@ class Zumba_Sniffs_PHP_DisallowMultipleUseSniff implements PHP_CodeSniffer_Sniff
      */
     public function register()
     {
-        return array(T_USE, T_CLASS);
+        return array(T_USE, T_CLASS, T_TRAIT);
 
     }//end register()
 
@@ -58,10 +58,12 @@ class Zumba_Sniffs_PHP_DisallowMultipleUseSniff implements PHP_CodeSniffer_Sniff
         $filename = $phpcsFile->getFilename();
 
         // disable for traits:
-        if ($tokens[$stackPtr]['code'] === T_CLASS) {
-            $this->seenClass[$filename] = true;
+        if ($tokens[$stackPtr]['code'] === T_CLASS ||
+            $tokens[$stackPtr]['code'] === T_TRAIT
+        ) {
+            $this->seenClassOrTrait[$filename] = true;
         }
-        if (!empty($this->seenClass[$filename])) {
+        if (!empty($this->seenClassOrTrait[$filename])) {
             return;
         }
 

--- a/test/data/use-in-trait.php
+++ b/test/data/use-in-trait.php
@@ -12,8 +12,7 @@ trait Foo {
 --EXPECT--
 
 --------------------------------------------------------------------------------
-FOUND 2 ERROR(S) AFFECTING 2 LINE(S)
+FOUND 1 ERROR(S) AFFECTING 1 LINE(S)
 --------------------------------------------------------------------------------
  6 | ERROR | The "use" has been used before on line 5
- 9 | ERROR | The "use" has been used before on line 5
 --------------------------------------------------------------------------------


### PR DESCRIPTION
Don't print an error when a use statement is within a trait