### PR TITLE
Updated the coding standard due to PHP 7 niceness.

### DIFF
--- a/Zumba/Sniffs/Commenting/VariableCommentSniff.php
+++ b/Zumba/Sniffs/Commenting/VariableCommentSniff.php
@@ -97,8 +97,6 @@ class Zumba_Sniffs_Commenting_VariableCommentSniff extends Squiz_Sniffs_Commenti
         $short = $comment->getShortComment();
         $long  = '';
         if (trim($short) === '') {
-            $error = 'Missing short description in variable doc comment';
-            $phpcsFile->addError($error, $commentStart, 'MissingShort');
             $newlineCount = 1;
         } else {
             // No extra newline before short description.
@@ -146,7 +144,7 @@ class Zumba_Sniffs_Commenting_VariableCommentSniff extends Squiz_Sniffs_Commenti
 
         // Exactly one blank line before tags.
         $tags = $this->commentParser->getTagOrders();
-        if (count($tags) > 1) {
+        if (count($tags) > 1 && trim($short) !== '') {
             $newlineSpan = $comment->getNewlineAfter();
             if ($newlineSpan !== 2) {
                 $error = 'There must be exactly one blank line before the tags in variable comment';
@@ -247,4 +245,3 @@ class Zumba_Sniffs_Commenting_VariableCommentSniff extends Squiz_Sniffs_Commenti
 
 
 }//end class
-?>


### PR DESCRIPTION
## This PR updates the Zumba code sniffer coding standard to, like, get with the times, man.

Since we are now on a newer version of PHP pretty much across the board, we have the ability to type-hint our params (even with scalars!) and define our function return types.  This makes the current DocBlock sniffing rules a bit draconian, and redundant.  If the type information is right there in the function signature, I shouldn't have to spell it out in the docblock (where it can get stale, be wrong, or just otherwise clutter my screen).

in other words, after merging this PR this code:
```php
/**
 * I am a valid DocBlock
 *
 * @param string
 * @return string
 */
public function isValid(string $msg) : string {
```

can now be written as:
```php
/**
 * I am a valid DocBlock
 */
public function isValid(string $msg) : string {
```

The sniffer will still complain (about params and return types) if a function signature does not use a type hint and or does not specify the type in the docblock:

```php
/**
 * I am NOT a valid DocBlock
 */
public function isValid($msg) {
```

## A couple more things:

The sniffer no longer forces you to add a short description to a class property docblock.  (you still need a docblock with `@var Type`, but forcing a short description is often redundant)

i.e. After this PR this DockBlock is valid:

```php
/**
 * @var string
 */
public $username;
```

Finally, documenting the magic `__toString` method is now completely optional.  If you need a docblock comment to know what `__toString` is doing, then we got 99 problems.