### PR TITLE
Fixing Sniffer Bugs

### DIFF
--- a/Zumba/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/Zumba/Sniffs/Commenting/FunctionCommentSniff.php
@@ -373,7 +373,7 @@ class Zumba_Sniffs_Commenting_FunctionCommentSniff extends Squiz_Sniffs_Commenti
                     ? $functionDef['parenthesis_closer'] + 4 // whitespace colon whitespace name
                     : $functionDef['scope_opener'];
                 while ($index++ < $end) {
-                    if ($tokens[$index]["code"] === \T_STRING) {
+                    if ($tokens[$index]["code"] === \T_STRING || $tokens[$index]["code"] === \T_ARRAY_HINT) {
                         return; // we're good.
                     }
                 }

--- a/Zumba/Sniffs/Commenting/VariableCommentSniff.php
+++ b/Zumba/Sniffs/Commenting/VariableCommentSniff.php
@@ -219,6 +219,7 @@ class Zumba_Sniffs_Commenting_VariableCommentSniff extends Squiz_Sniffs_Commenti
                 $this->currentFile->addError($error, $errorPos, 'MissingVarType');
                 return;
             } else {
+				$content = $content == 'bool' ? 'boolean' : ($content == 'int' ? 'integer' : $content);
                 $suggestedType = PHP_CodeSniffer::suggestType($content);
                 if ($content !== $suggestedType) {
                     $error = 'Expected "%s"; found "%s" for @var tag in variable comment';

--- a/Zumba/Sniffs/Commenting/VariableCommentSniff.php
+++ b/Zumba/Sniffs/Commenting/VariableCommentSniff.php
@@ -219,7 +219,7 @@ class Zumba_Sniffs_Commenting_VariableCommentSniff extends Squiz_Sniffs_Commenti
                 $this->currentFile->addError($error, $errorPos, 'MissingVarType');
                 return;
             } else {
-				$content = $content == 'bool' ? 'boolean' : ($content == 'int' ? 'integer' : $content);
+                $content = $content == 'bool' ? 'boolean' : ($content == 'int' ? 'integer' : $content);
                 $suggestedType = PHP_CodeSniffer::suggestType($content);
                 if ($content !== $suggestedType) {
                     $error = 'Expected "%s"; found "%s" for @var tag in variable comment';


### PR DESCRIPTION
This makes it stop returning an error when variable types are declared as `bool` or `int` instead of `boolean` and `integer` respectively.

It also makes it so the sniffer passes for function return types of `array`. Currently there's an issue where it throws an error.