### PR TITLE
Nullable type spacing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: php
 sudo: false
 
 php:
-  - 5.6
   - 7.2
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: php
+
+sudo: false
+
+php:
+  - 5.6
+  - 7.2
+
+before_script:
+  - composer install
+
+script: ./vendor/bin/phpunit --configuration phpunit.xml --verbose --coverage-text
+
+notifications:
+  email: false

--- a/Zumba/Sniffs/WhiteSpace/OperatorSpacingSniff.php
+++ b/Zumba/Sniffs/WhiteSpace/OperatorSpacingSniff.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Zumba_Sniffs_ControlStructures_MultiLineConditionSniff.
+ *
+ * PHP version 5
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ */
+
+if (class_exists('Squiz_Sniffs_WhiteSpace_OperatorSpacingSniff', true) === false) {
+    $error = 'Class Squiz_Sniffs_WhiteSpace_OperatorSpacingSniff not found';
+    throw new PHP_CodeSniffer_Exception($error);
+}
+
+/**
+ * Zumba_Sniffs_WhiteSpace_OperatorSpacingSniff
+ *
+ * Handle spacing around operators.
+ *
+ * Overridden to handle PHP 7 nullable types.
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ */
+class Zumba_Sniffs_WhiteSpace_OperatorSpacingSniff
+    extends Squiz_Sniffs_WhiteSpace_OperatorSpacingSniff
+    implements PHP_CodeSniffer_Sniff {
+
+    private const NULLABLE_TYPE_SKIP_TOKENS = [
+        T_WHITESPACE,
+        T_NS_SEPARATOR,
+        T_STRING,
+    ];
+
+    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr) {
+        $tokens = $phpcsFile->getTokens();
+        if ($this->isProbablyNullableType($phpcsFile, $tokens, $stackPtr)) {
+            return;
+        }
+        return parent::process($phpcsFile, $stackPtr);
+    }
+
+    private function isProbablyNullableType(PHP_CodeSniffer_File $phpcsFile, $tokens, $stackPtr) {
+        $token = $tokens[$stackPtr];
+        if ($token['code'] !== T_INLINE_THEN) {
+            return false;
+        }
+
+        $namespaceTokenOrIdentifier = $phpcsFile->findNext(
+            [T_NS_SEPARATOR, T_STRING],
+            $stackPtr + 1,
+            null,
+            false,
+            null,
+            true
+        );
+        if (!$namespaceTokenOrIdentifier) {
+            return false;
+        }
+        $maybeVariableOrOpenBrace = $phpcsFile->findNext(
+            [T_WHITESPACE, T_NS_SEPARATOR, T_STRING],
+            $stackPtr + 1,
+            null,
+            true,
+            null,
+            true
+        );
+        if (!$maybeVariableOrOpenBrace) {
+            return false;
+        }
+        // if it's a variable, then assume it's a parameter with a nullable type:
+        if ($tokens[$maybeVariableOrOpenBrace]['code'] === T_VARIABLE) {
+            return true;
+        }
+        // if it's an opening block, assume it's a return type with a nullable type:
+        if ($tokens[$maybeVariableOrOpenBrace]['code'] === T_OPEN_CURLY_BRACKET) {
+            return true;
+        }
+        return false;
+    }
+
+}

--- a/Zumba/Sniffs/WhiteSpace/OperatorSpacingSniff.php
+++ b/Zumba/Sniffs/WhiteSpace/OperatorSpacingSniff.php
@@ -32,7 +32,7 @@ class Zumba_Sniffs_WhiteSpace_OperatorSpacingSniff
         if ($this->isProbablyNullableType($phpcsFile, $tokens, $stackPtr)) {
             return;
         }
-        return parent::process($phpcsFile, $stackPtr);
+        parent::process($phpcsFile, $stackPtr);
     }
 
     private function isProbablyNullableType(PHP_CodeSniffer_File $phpcsFile, $tokens, $stackPtr) {

--- a/Zumba/Sniffs/WhiteSpace/OperatorSpacingSniff.php
+++ b/Zumba/Sniffs/WhiteSpace/OperatorSpacingSniff.php
@@ -27,12 +27,6 @@ class Zumba_Sniffs_WhiteSpace_OperatorSpacingSniff
     extends Squiz_Sniffs_WhiteSpace_OperatorSpacingSniff
     implements PHP_CodeSniffer_Sniff {
 
-    private const NULLABLE_TYPE_SKIP_TOKENS = [
-        T_WHITESPACE,
-        T_NS_SEPARATOR,
-        T_STRING,
-    ];
-
     public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr) {
         $tokens = $phpcsFile->getTokens();
         if ($this->isProbablyNullableType($phpcsFile, $tokens, $stackPtr)) {

--- a/Zumba/ruleset.xml
+++ b/Zumba/ruleset.xml
@@ -69,7 +69,11 @@
 	<rule ref="Squiz.WhiteSpace.LanguageConstructSpacing"/>
 	<rule ref="Squiz.WhiteSpace.LogicalOperatorSpacing"/>
 	<rule ref="Squiz.WhiteSpace.MemberVarSpacing"/>
+	<!-- Excluded because it doesn't work with nullable types
 	<rule ref="Squiz.WhiteSpace.OperatorSpacing"/>
+	-->
+	<rule ref="Zumba.WhiteSpace.OperatorSpacing"/>
+
 	<rule ref="Squiz.WhiteSpace.ScopeClosingBrace"/>
 	<rule ref="Squiz.WhiteSpace.SemicolonSpacing"/>
 	<rule ref="Generic.WhiteSpace.ScopeIndent">

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
 		}
 	],
 	"require": {
-		"php": ">=5.3.10",
+		"php": ">=5.6",
 		"squizlabs/php_codesniffer": "1.5.3"
 	},
 	"require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -15,10 +15,10 @@
 		}
 	],
 	"require": {
-		"php": ">=7.2",
+		"php": ">=7.1",
 		"squizlabs/php_codesniffer": "1.5.3"
 	},
 	"require-dev": {
-		"phpunit/phpunit": "^4"
+		"phpunit/phpunit": "5.7.27"
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
 		}
 	],
 	"require": {
-		"php": ">=5.6",
+		"php": ">=7.2",
 		"squizlabs/php_codesniffer": "1.5.3"
 	},
 	"require-dev": {

--- a/test/data/nullable-type.php
+++ b/test/data/nullable-type.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Zumba\CodingStandards\Test;
+
+class NullableTypeTest {
+	/**
+	 * Test that the the nullable ternary space doesn't break.
+     *
+     * @return static
+	 */
+	public function local(?NullableTypeTest $nullableType) : self {
+        $foo = $bar?'cheese':'baz';
+	}
+
+	public function relative(?Relative\Test $nullableType) : self {
+	}
+
+	public function absolute(?\Zumba\Test $nullableType) : self {
+	}
+
+
+}
+?>
+--EXPECT--
+--------------------------------------------------------------------------------
+FOUND 4 ERROR(S) AFFECTING 1 LINE(S)
+--------------------------------------------------------------------------------
+12 | ERROR | Expected 1 space before "?"; 0 found
+12 | ERROR | Expected 1 space after "?"; 0 found
+12 | ERROR | Expected 1 space before ":"; 0 found
+12 | ERROR | Expected 1 space after ":"; 0 found
+--------------------------------------------------------------------------------
+

--- a/test/data/nullable-type.php
+++ b/test/data/nullable-type.php
@@ -2,32 +2,82 @@
 
 namespace Zumba\CodingStandards\Test;
 
+use OtherType as RelativeType;
 class NullableTypeTest {
 	/**
-	 * Test that the the nullable ternary space doesn't break.
-     *
-     * @return static
+	 * NullableTypeTest constructor.
+	 *
+	 * @param NullableTypeTest|null $nullableType
 	 */
-	public function local(?NullableTypeTest $nullableType) : self {
-        $foo = $bar?'cheese':'baz';
+	public function __construct(
+		?NullableTypeTest $nullableType,
+		?Relative\NullableType $relativeNullableType,
+		?\Zumba\CodingStandards\Test\NullableTypeTest $absoluteNullableType
+	) {
+		$this->foo = $nullableType?'cheese':'bar';
+		$this->bar = $nullableType ?\Zumba\CodingStandards\Test\NullableTypeTest::$staticVar : 2;
+		$this->bar = $nullableType ?
+			function(?\Zumba\CodingStandards\Test\NullableTypeTest $staticVar) {
+
+			} : 2;
 	}
 
-	public function relative(?Relative\Test $nullableType) : self {
+	/**
+	 * Description
+	 *
+	 * @param NullableTypeTest|null $nullableType
+	 * @return NullableTypeTest|null
+	 */
+	public function returnType(?NullableTypeTest $nullableType) : ?NullableTypeTest {
+		return null;
 	}
 
-	public function absolute(?\Zumba\Test $nullableType) : self {
+	/**
+	 * Description
+	 *
+	 * @return Relative\NullableType|null
+	 */
+	public function relativeReturn() : ?Relative\NullableType {
+		return null;
 	}
 
+	/**
+	 * Description
+	 *
+	 * @return NullableTypeTest|null
+	 */
+	public function absoluteReturn() : ?\Zumba\CodingStandards\Test\NullableTypeTest {
+		return null;
+	}
 
+	/**
+	 * Relative param
+	 *
+	 * @param null|\Zumba\CodingStandards\Test\Relative\NullableType $relativeParam
+	 */
+	public function relativeParam(?Relative\NullableType $relativeParam) : void {
+
+	}
+
+	/**
+	 * Absolute param.
+	 *
+	 * @param \Zumba\CodingStandards\Test\NullableTypeTest $test
+	 */
+	public function absoluteParam(\Zumba\CodingStandards\Test\NullableTypeTest $test) : void {
+
+	}
 }
+
 ?>
 --EXPECT--
 --------------------------------------------------------------------------------
-FOUND 4 ERROR(S) AFFECTING 1 LINE(S)
+FOUND 5 ERROR(S) AFFECTING 2 LINE(S)
 --------------------------------------------------------------------------------
-12 | ERROR | Expected 1 space before "?"; 0 found
-12 | ERROR | Expected 1 space after "?"; 0 found
-12 | ERROR | Expected 1 space before ":"; 0 found
-12 | ERROR | Expected 1 space after ":"; 0 found
+ 17 | ERROR | Expected 1 space before "?"; 0 found
+ 17 | ERROR | Expected 1 space after "?"; 0 found
+ 17 | ERROR | Expected 1 space before ":"; 0 found
+ 17 | ERROR | Expected 1 space after ":"; 0 found
+ 18 | ERROR | Expected 1 space after "?"; 0 found
 --------------------------------------------------------------------------------
 


### PR DESCRIPTION
This fixes the issue of the coding standards filter warning about spaces when using nullable types:

```php
function(?string $foo) {
}
```

can be used without a space around the `?`, instead of needing:

```php
function( ? string $foo ) {
}
```