### PR TITLE
Double Quote Usage

### DIFF
--- a/Zumba/ruleset.xml
+++ b/Zumba/ruleset.xml
@@ -62,6 +62,7 @@
 	<rule ref="Squiz.Scope.MethodScope"/>
 	<rule ref="Squiz.Scope.StaticThisUsage"/>
 
+	<rule ref="Squiz.Strings.DoubleQuoteUsage"/>
 	<rule ref="Generic.Strings.UnnecessaryStringConcat"/>
 
 	<rule ref="Squiz.WhiteSpace.CastSpacing"/>

--- a/test/data/closure-return.php
+++ b/test/data/closure-return.php
@@ -9,7 +9,7 @@ function foobar() {
 	$hello = function() {
 		return 'hello';
 	};
-	return "string";
+	return 'string';
 }
 ?>
 --EXPECT--

--- a/test/data/multireturn.php
+++ b/test/data/multireturn.php
@@ -6,10 +6,10 @@
  * @return void
  */
 function foobar() {
-	if (strlen("hello")) {
+	if (strlen('hello')) {
 		return;
 	}
-	return "hello";
+	return 'hello';
 }
 ?>
 --EXPECT--


### PR DESCRIPTION
This PR is to enforce using single quotes around strings. It also enforces concatenation of strings with variables. So these would no longer be allowed:

-  `$a = "test";`
-  `$a = "test$name";`

And these would be proper replacements:
-  `$a = 'test';`
-  `$a = 'test' . $name;`
